### PR TITLE
Without Spring Security

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,6 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
-	implementation "org.springframework.boot:spring-boot-starter-security"
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'io.projectreactor:reactor-test'

--- a/src/main/java/com/github/david0/streamedheaderproblem/StreamedHeaderProblemApplication.java
+++ b/src/main/java/com/github/david0/streamedheaderproblem/StreamedHeaderProblemApplication.java
@@ -1,29 +1,54 @@
 package com.github.david0.streamedheaderproblem;
 
-import static org.springframework.security.web.util.matcher.AntPathRequestMatcher.antMatcher;
+import java.io.IOException;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 
 @SpringBootApplication
-@EnableWebSecurity
 
 public class StreamedHeaderProblemApplication {
+
+	private static final Log logger = LogFactory.getLog(StreamedHeaderProblemApplication.class);
 
 	public static void main(String[] args) {
 		SpringApplication.run(StreamedHeaderProblemApplication.class, args);
 	}
 
 	@Bean
-	SecurityFilterChain allowAll(HttpSecurity http) throws Exception {
-		http.authorizeHttpRequests(authorize -> authorize
-				.requestMatchers(antMatcher("/**")).permitAll());
-		http.csrf(AbstractHttpConfigurer::disable);
-		return http.build();
+	Filter headerWriter() {
+		return new HeaderWriterFilter();
+	}
+
+	private static class HeaderWriterFilter implements Filter {
+
+		@Override
+		public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+			HttpServletRequest req = (HttpServletRequest) request;
+			HttpServletResponse res = (HttpServletResponse) response;
+			try {
+				chain.doFilter(req, res);
+			} finally {
+				logger.error("writing headers as part of returning filter");
+				((HttpServletResponse) response).setHeader("X-One", "one");
+				((HttpServletResponse) response).setHeader("X-Two", "two");
+				((HttpServletResponse) response).setHeader("X-Three", "three");
+				((HttpServletResponse) response).setHeader("X-Four", "four");
+				((HttpServletResponse) response).setHeader("X-Five", "five");
+			}
+		}
+
+
 	}
 }


### PR DESCRIPTION
This PR removes Spring Security and demonstrates that the empty header error happens without it.

I noticed that sometimes a different error comes up, also equally inscrutable, related to flawed header writing.

Other than the reported empty headers error, I sometimes saw this:
```
Caused by: org.springframework.web.reactive.function.UnsupportedMediaTypeException: Content type 'application/octet-stream' not supported for bodyType=com.github.david0.streamedheaderproblem.FooController$Identifier
```
